### PR TITLE
Bug 1748777: kubectl: remove usage info from bad flag error msg

### DIFF
--- a/pkg/util/templates/templater.go
+++ b/pkg/util/templates/templater.go
@@ -44,6 +44,7 @@ func ActsAsRootCommand(cmd *cobra.Command, filters []string, groups ...CommandGr
 		CommandGroups: groups,
 		Filtered:      filters,
 	}
+	cmd.SetFlagErrorFunc(templater.FlagErrorFunc())
 	cmd.SetUsageFunc(templater.UsageFunc())
 	cmd.SetHelpFunc(templater.HelpFunc())
 	return templater
@@ -64,6 +65,18 @@ type templater struct {
 	RootCmd       *cobra.Command
 	CommandGroups
 	Filtered []string
+}
+
+func (templater *templater) FlagErrorFunc(exposedFlags ...string) func(*cobra.Command, error) error {
+	return func(c *cobra.Command, err error) error {
+		c.SilenceUsage = true
+		switch c.CalledAs() {
+		case "options":
+			return fmt.Errorf("%s\nRun '%s' without flags.", err, c.CommandPath())
+		default:
+			return fmt.Errorf("%s\nSee '%s --help' for usage.", err, c.CommandPath())
+		}
+	}
 }
 
 func (templater *templater) ExposeFlags(cmd *cobra.Command, flags ...string) FlagExposer {


### PR DESCRIPTION
This is a pick of upstream commit 82423, to stop printing usage info on a bad flag error. Instead, only print a suggestion to run help command.  Will bump openshift/oc to bring this is. 

/cc @soltysh 