### PR TITLE
UPSTREAM: 85490: don't error if set-resources patch is empty

### DIFF
--- a/pkg/cmd/set/set_resources.go
+++ b/pkg/cmd/set/set_resources.go
@@ -267,7 +267,6 @@ func (o *SetResourcesOptions) Run() error {
 
 		//no changes
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			allErrs = append(allErrs, fmt.Errorf("info: %s was not changed\n", name))
 			continue
 		}
 

--- a/pkg/cmd/set/set_subject.go
+++ b/pkg/cmd/set/set_subject.go
@@ -247,7 +247,6 @@ func (o *SubjectOptions) Run(fn updateSubjects) error {
 
 		//no changes
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			allErrs = append(allErrs, fmt.Errorf("info: %s was not changed\n", name))
 			continue
 		}
 


### PR DESCRIPTION
/assign @soltysh 

Pull this into 4.4? Or, wait until next kube bump? 
https://bugzilla.redhat.com/show_bug.cgi?id=1773266
