### PR TITLE
UPSTREAM: 87361: fix kubectl drain ignore daemonsets and others

### DIFF
--- a/pkg/cmd/drain/drain_test.go
+++ b/pkg/cmd/drain/drain_test.go
@@ -867,7 +867,7 @@ func TestDrain(t *testing.T) {
 				switch {
 				case recovered != nil && !sawFatal:
 					t.Fatalf("got panic: %v", recovered)
-				case test.expectDelete && test.expectFatal && !sawFatal:
+				case test.expectFatal && !sawFatal:
 					t.Fatalf("%s: unexpected non-error when using %s", test.description, currMethod)
 				case !test.expectFatal && sawFatal:
 					t.Fatalf("%s: unexpected error when using %s: %s", test.description, currMethod, fatalMsg)
@@ -903,7 +903,7 @@ func TestDrain(t *testing.T) {
 					t.Fatalf("%s: same pod deleted %d times and evicted %d times", test.description, deletions, evictions)
 				}
 
-				if test.expectDelete && len(test.expectWarning) > 0 {
+				if len(test.expectWarning) > 0 {
 					if len(errBuf.String()) == 0 {
 						t.Fatalf("%s: expected warning, but found no stderr output", test.description)
 					}

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -155,12 +155,13 @@ func (d *Helper) GetPodsForDeletion(nodeName string) (*podDeleteList, []error) {
 				break
 			}
 		}
-		if status.delete {
-			pods = append(pods, podDelete{
-				pod:    pod,
-				status: status,
-			})
-		}
+		// Add the pod to podDeleteList no matter what podDeleteStatus is,
+		// those pods whose podDeleteStatus is false like DaemonSet will
+		// be catched by list.errors()
+		pods = append(pods, podDelete{
+			pod:    pod,
+			status: status,
+		})
 	}
 
 	list := &podDeleteList{items: pods}


### PR DESCRIPTION
To fix https://bugzilla.redhat.com/show_bug.cgi?id=1835739