### PR TITLE
UPSTREAM 91692: Make kubectl tolerate other versions of the CSR API

### DIFF
--- a/pkg/cmd/certificates/certificates.go
+++ b/pkg/cmd/certificates/certificates.go
@@ -222,7 +222,7 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 		WithScheme(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...).
 		ContinueOnError().
 		FilenameParam(false, &o.FilenameOptions).
-		ResourceNames("certificatesigningrequest", o.csrNames...).
+		ResourceNames("certificatesigningrequests.v1beta1.certificates.k8s.io", o.csrNames...).
 		RequireObject(true).
 		Flatten().
 		Latest().
@@ -232,7 +232,10 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 			return err
 		}
 		for i := 0; ; i++ {
-			csr := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			csr, ok := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
+			if !ok {
+				return fmt.Errorf("can only handle certificates.k8s.io/v1beta1 certificate signing requests")
+			}
 			csr, hasCondition := modify(csr)
 			if !hasCondition || force {
 				_, err = clientSet.CertificateSigningRequests().UpdateApproval(context.TODO(), csr, metav1.UpdateOptions{})


### PR DESCRIPTION
Generated with:

```console
$ git remote add upstream git://github.com/kubernetes/kubernetes.git
$ git fetch upstream
$ git cherry-pick 789dde9a3b8b60c788492341effdea8a29cfd19e
$ git commit --amend # add the UPSTREAM prefix and this generation note
```

To pull in kubernetes/kubernetes#91692.