### PR TITLE
generic ephemeral volumes: drop ReadOnly field

### DIFF
--- a/pkg/describe/describe.go
+++ b/pkg/describe/describe.go
@@ -1072,7 +1072,6 @@ func printEphemeralVolumeSource(ephemeral *corev1.EphemeralVolumeSource, w Prefi
 				Spec:       ephemeral.VolumeClaimTemplate.Spec,
 			}, false /* not a full PVC */)
 	}
-	w.Write(LEVEL_2, "ReadOnly:\t%v\n", ephemeral.ReadOnly)
 }
 
 func printRBDVolumeSource(rbd *corev1.RBDVolumeSource, w PrefixWriter) {

--- a/pkg/describe/describe.go
+++ b/pkg/describe/describe.go
@@ -2161,7 +2161,7 @@ func describeJob(job *batchv1.Job, events *corev1.EventList) (string, error) {
 		} else {
 			w.Write(LEVEL_0, "Completions:\t<unset>\n")
 		}
-		if job.Spec.CompletionMode != "" {
+		if job.Spec.CompletionMode != nil {
 			w.Write(LEVEL_0, "Completion Mode:\t%s\n", job.Spec.CompletionMode)
 		}
 		if job.Status.StartTime != nil {
@@ -2177,7 +2177,7 @@ func describeJob(job *batchv1.Job, events *corev1.EventList) (string, error) {
 			w.Write(LEVEL_0, "Active Deadline Seconds:\t%ds\n", *job.Spec.ActiveDeadlineSeconds)
 		}
 		w.Write(LEVEL_0, "Pods Statuses:\t%d Running / %d Succeeded / %d Failed\n", job.Status.Active, job.Status.Succeeded, job.Status.Failed)
-		if job.Spec.CompletionMode == batchv1.IndexedCompletion {
+		if job.Spec.CompletionMode != nil && *job.Spec.CompletionMode == batchv1.IndexedCompletion {
 			w.Write(LEVEL_0, "Completed Indexes:\t%s\n", capIndexesListOrNone(job.Status.CompletedIndexes, 50))
 		}
 		DescribePodTemplate(&job.Spec.Template, w)

--- a/pkg/describe/describe_test.go
+++ b/pkg/describe/describe_test.go
@@ -2064,6 +2064,7 @@ func TestDescribeDeployment(t *testing.T) {
 }
 
 func TestDescribeJob(t *testing.T) {
+	indexedCompletion := batchv1.IndexedCompletion
 	cases := map[string]struct {
 		job                  *batchv1.Job
 		wantCompletedIndexes string
@@ -2074,9 +2075,7 @@ func TestDescribeJob(t *testing.T) {
 					Name:      "bar",
 					Namespace: "foo",
 				},
-				Spec: batchv1.JobSpec{
-					CompletionMode: batchv1.NonIndexedCompletion,
-				},
+				Spec: batchv1.JobSpec{},
 			},
 		},
 		"no indexes": {
@@ -2086,7 +2085,7 @@ func TestDescribeJob(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: batchv1.JobSpec{
-					CompletionMode: batchv1.IndexedCompletion,
+					CompletionMode: &indexedCompletion,
 				},
 			},
 			wantCompletedIndexes: "<none>",
@@ -2098,7 +2097,7 @@ func TestDescribeJob(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: batchv1.JobSpec{
-					CompletionMode: batchv1.IndexedCompletion,
+					CompletionMode: &indexedCompletion,
 				},
 				Status: batchv1.JobStatus{
 					CompletedIndexes: "0-5,7,9,10,12,13,15,16,18,20,21,23,24,26,27,29,30,32",
@@ -2113,7 +2112,7 @@ func TestDescribeJob(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: batchv1.JobSpec{
-					CompletionMode: batchv1.IndexedCompletion,
+					CompletionMode: &indexedCompletion,
 				},
 				Status: batchv1.JobStatus{
 					CompletedIndexes: "0-5,7,9,10,12,13,15,16,18,20,21,23,24,26,27,29,30,32-34,36,37",


### PR DESCRIPTION
pick upstream 
```
   generic ephemeral volumes: drop ReadOnly field
    
    As discussed during the alpha review, the ReadOnly field is not really
    needed because volume mounts can also be read-only. It's a historical
    oddity that can be avoided for generic ephemeral volumes as part
    of the promotion to beta.
    
    Kubernetes-commit: 555d4a12bf58f19cbd79f866e2abce13490bde40
```
and 
```
    Only default Job fields when feature gates are enabled
    
    Also use pointer for completionMode enum
    
    Kubernetes-commit: e6c3d7b34dff0324adb80591c00519b6f6a4a2e1
```